### PR TITLE
Update dlib to 19.4 and add support for Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 language: generic
 
 os: osx
-osx_image: beta-xcode6.1
+osx_image: xcode7.3
 
 env:
   matrix:

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -83,4 +83,18 @@ source run_conda_forge_build_setup
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_NPY=110
+    export CONDA_PY=36
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_NPY=111
+    export CONDA_PY=36
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 EOF

--- a/recipe/add_global_cxx_release.patch
+++ b/recipe/add_global_cxx_release.patch
@@ -1,6 +1,6 @@
---- dlib/add_global_compiler_switch.cmake
-+++ dlib/add_global_compiler_switch.cmake
-@@ -7,18 +7,18 @@
+--- a/dlib/cmake_utils/add_global_compiler_switch.cmake
++++ b/dlib/cmake_utils/add_global_compiler_switch.cmake
+@@ -7,18 +7,18 @@ cmake_minimum_required(VERSION 2.8.12)
  macro ( add_global_compiler_switch switch_name )
     # If removing the switch would change the flags then it's already present
     # and we don't need to do anything.

--- a/recipe/lapack_sgetrf.patch
+++ b/recipe/lapack_sgetrf.patch
@@ -1,6 +1,6 @@
---- dlib/cmake_find_blas.txt
-+++ dlib/cmake_find_blas.txt
-@@ -140,15 +140,8 @@
+--- a/dlib/cmake_utils/cmake_find_blas.txt
++++ b/dlib/cmake_utils/cmake_find_blas.txt
+@@ -156,15 +156,8 @@ if (UNIX OR MINGW)
           set(blas_found 1)
           message(STATUS "Found OpenBLAS library")
           set(CMAKE_REQUIRED_LIBRARIES ${blas_libraries})

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dlib" %}
-{% set version = "19.0" %}
+{% set version = "19.4" %}
 {% set blas_variant = "openblas" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/davisking/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: a6463524cdb1d275ab408f182b0d47af143179fde7f1dd97074dc25f2f9a2676
+  sha256: 2bed9669f1a5c436579498d0806b27a9b60c42a975a9b6e67b594b40f58b1a88
 
   patches:
     - osx_jpeg.patch                # [osx]
@@ -18,7 +18,7 @@ source:
     - add_global_cxx_release.patch
 
 build:
-  number: 200
+  number: 0
   features:                    # [not win]
     - blas_{{ blas_variant }}  # [not win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,22 +27,22 @@ requirements:
    - python
    - cmake
    - toolchain
-   - openblas 0.2.18|0.2.18.*.    # [not win]
+   - openblas 0.2.19|0.2.19.*.    # [not win]
    - blas 1.1 {{ blas_variant }}  # [not win]
    - numpy x.x
-   - boost 1.61.*
+   - boost 1.62.*
    - jpeg 9*                      # [not win]
-   - libpng >=1.6.21,<1.7
+   - libpng >=1.6.23,<1.7
    - sqlite 3.13.*                # [not win]
 
   run:
    - python
-   - openblas 0.2.18|0.2.18.*.    # [not win]
+   - openblas 0.2.19|0.2.19.*.    # [not win]
    - blas 1.1 {{ blas_variant }}  # [not win]
    - numpy x.x
-   - boost 1.61.*
+   - boost 1.62.*
    - jpeg 9*                      # [not win]
-   - libpng >=1.6.21,<1.7
+   - libpng >=1.6.23,<1.7
    - sqlite 3.13.*                # [not win]
 
 test:

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -49,8 +49,9 @@ class TestDlib(unittest.TestCase):
     def setUpClass(cls):
         # Get paths to test data
         test_dir_path = os.path.dirname(os.path.abspath(__file__))
-        cls.face_jpg_path = os.path.join(test_dir_path, 'face.jpg')
-        cls.face_png_path = os.path.join(test_dir_path, 'face.png')
+        cls.face_jpg_path = os.path.join(test_dir_path, 'test_data/face.jpg')
+        cls.face_png_path = os.path.join(test_dir_path, 'test_data/face.png')
+        cls.images_xml_path = os.path.join(test_dir_path, 'test_data/images.xml')
 
         # Download shape_predictor model
         print('Downloading {} to ./{}'.format(SHAPE_PREDICTOR_URL, 
@@ -84,7 +85,7 @@ class TestDlib(unittest.TestCase):
         options.C = 1
         options.num_threads = 1
 
-        dlib.train_simple_object_detector('images.xml', "test.svm", options)
+        dlib.train_simple_object_detector(self.images_xml_path, "test.svm", options)
         self.assertTrue(os.path.exists('./test.svm'))
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds builds for Python 3.6 and updates dlib to the newest version (19.4).

I also reset the build number to 0 as in the instructions.