### PR TITLE
Update to 19.10, fix lapack patch, fix numpy deps

### DIFF
--- a/recipe/lapack_sgetrf.patch
+++ b/recipe/lapack_sgetrf.patch
@@ -1,6 +1,6 @@
---- dlib/cmake_utils/cmake_find_blas.txt
-+++ dlib/cmake_utils/cmake_find_blas.txt
-@@ -156,15 +156,8 @@
+--- dlib/cmake_utils/find_blas.cmake
++++ dlib/cmake_utils/find_blas.cmake
+@@ -175,15 +175,8 @@
           set(blas_found 1)
           message(STATUS "Found OpenBLAS library")
           set(CMAKE_REQUIRED_LIBRARIES ${blas_libraries})
@@ -18,4 +18,3 @@
        endif()
        mark_as_advanced( cblas_lib)
     endif()
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dlib" %}
-{% set version = "19.9" %}
+{% set version = "19.10" %}
 {% set blas_variant = "openblas" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/davisking/{{ name }}/archive/v{{ version }}.tar.gz
-  sha1: 9ff9573dab29136e7157e71e81c26baff53254fa
+  sha1: 624722775d0ff8e4f26889bd7d1d980fcb096927
 
   patches:
     - osx_jpeg.patch           # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,9 +43,9 @@ requirements:
     - python
     - openblas 0.2.20|0.2.20.*     # [not win]
     - blas 1.1 {{ blas_variant }}  # [not win]
-    - numpy 1.8.*                  # [not (win and (py35 or py36))]
-    - numpy 1.9.*                  # [win and py35]
-    - numpy 1.11.*                 # [win and py36]
+    - numpy >=1.8.*                # [not (win and (py35 or py36))]
+    - numpy >=1.9.*                # [win and py35]
+    - numpy >=1.11.*               # [win and py36]
     - jpeg 9*                      # [not win]
     - libpng >=1.6.32,<1.6.35
     - sqlite 3.20.*                # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,3 +72,4 @@ about:
 extra:
   recipe-maintainers:
     - patricksnape
+    - aldanor

--- a/recipe/win_jpeg_png.patch
+++ b/recipe/win_jpeg_png.patch
@@ -1,9 +1,10 @@
 --- dlib/CMakeLists.txt
 +++ dlib/CMakeLists.txt
-@@ -350,66 +350,11 @@
+@@ -373,67 +373,11 @@
+       endif()
  
        if (DLIB_PNG_SUPPORT)
-          # try to find libpng 
+-         # try to find libpng 
 -         find_package(PNG QUIET)
 -         # Make sure there isn't something wrong with the version of LIBPNG
 -         # installed on this system.  
@@ -64,15 +65,15 @@
 -            endif()
 -            set(REQUIRES_LIBS "")
 -         endif()
++         # try to find libpng
 +         find_package(PNG)
-+
 +         include_directories(${PNG_INCLUDE_DIR})
 +         set (dlib_needed_libraries ${dlib_needed_libraries} ${PNG_LIBRARIES})
 +         set(REQUIRES_LIBS " libpng")
           set(source_files ${source_files}
              image_loader/png_loader.cpp
              image_saver/save_png.cpp
-@@ -417,68 +362,54 @@
+@@ -441,68 +385,54 @@
        endif()
  
        if (DLIB_JPEG_SUPPORT)
@@ -92,100 +93,100 @@
 -            # If we can't find libjpeg then statically compile it in.
 -            add_definitions(-DDLIB_JPEG_STATIC)
 -            set(source_files ${source_files}
--                  external/libjpeg/jcomapi.cpp
--                  external/libjpeg/jdapimin.cpp
--                  external/libjpeg/jdapistd.cpp
--                  external/libjpeg/jdatasrc.cpp
--                  external/libjpeg/jdcoefct.cpp
--                  external/libjpeg/jdcolor.cpp
--                  external/libjpeg/jddctmgr.cpp
--                  external/libjpeg/jdhuff.cpp
--                  external/libjpeg/jdinput.cpp
--                  external/libjpeg/jdmainct.cpp
--                  external/libjpeg/jdmarker.cpp
--                  external/libjpeg/jdmaster.cpp
--                  external/libjpeg/jdmerge.cpp
--                  external/libjpeg/jdphuff.cpp
--                  external/libjpeg/jdpostct.cpp
--                  external/libjpeg/jdsample.cpp
--                  external/libjpeg/jerror.cpp
--                  external/libjpeg/jidctflt.cpp
--                  external/libjpeg/jidctfst.cpp
--                  external/libjpeg/jidctint.cpp
--                  external/libjpeg/jidctred.cpp
--                  external/libjpeg/jmemmgr.cpp
--                  external/libjpeg/jmemnobs.cpp
--                  external/libjpeg/jquant1.cpp
--                  external/libjpeg/jquant2.cpp
--                  external/libjpeg/jutils.cpp  
--                  external/libjpeg/jcapimin.cpp
--                  external/libjpeg/jdatadst.cpp
--                  external/libjpeg/jcparam.cpp
--                  external/libjpeg/jcapistd.cpp
--                  external/libjpeg/jcmarker.cpp
--                  external/libjpeg/jcinit.cpp
--                  external/libjpeg/jcmaster.cpp
--                  external/libjpeg/jcdctmgr.cpp
--                  external/libjpeg/jccoefct.cpp  
--                  external/libjpeg/jccolor.cpp  
--                  external/libjpeg/jchuff.cpp  
--                  external/libjpeg/jcmainct.cpp  
--                  external/libjpeg/jcphuff.cpp  
--                  external/libjpeg/jcprepct.cpp  
--                  external/libjpeg/jcsample.cpp
--                  external/libjpeg/jfdctint.cpp
--                  external/libjpeg/jfdctflt.cpp
--                  external/libjpeg/jfdctfst.cpp
--                  )
+-               external/libjpeg/jcomapi.cpp
+-               external/libjpeg/jdapimin.cpp
+-               external/libjpeg/jdapistd.cpp
+-               external/libjpeg/jdatasrc.cpp
+-               external/libjpeg/jdcoefct.cpp
+-               external/libjpeg/jdcolor.cpp
+-               external/libjpeg/jddctmgr.cpp
+-               external/libjpeg/jdhuff.cpp
+-               external/libjpeg/jdinput.cpp
+-               external/libjpeg/jdmainct.cpp
+-               external/libjpeg/jdmarker.cpp
+-               external/libjpeg/jdmaster.cpp
+-               external/libjpeg/jdmerge.cpp
+-               external/libjpeg/jdphuff.cpp
+-               external/libjpeg/jdpostct.cpp
+-               external/libjpeg/jdsample.cpp
+-               external/libjpeg/jerror.cpp
+-               external/libjpeg/jidctflt.cpp
+-               external/libjpeg/jidctfst.cpp
+-               external/libjpeg/jidctint.cpp
+-               external/libjpeg/jidctred.cpp
+-               external/libjpeg/jmemmgr.cpp
+-               external/libjpeg/jmemnobs.cpp
+-               external/libjpeg/jquant1.cpp
+-               external/libjpeg/jquant2.cpp
+-               external/libjpeg/jutils.cpp  
+-               external/libjpeg/jcapimin.cpp
+-               external/libjpeg/jdatadst.cpp
+-               external/libjpeg/jcparam.cpp
+-               external/libjpeg/jcapistd.cpp
+-               external/libjpeg/jcmarker.cpp
+-               external/libjpeg/jcinit.cpp
+-               external/libjpeg/jcmaster.cpp
+-               external/libjpeg/jcdctmgr.cpp
+-               external/libjpeg/jccoefct.cpp  
+-               external/libjpeg/jccolor.cpp  
+-               external/libjpeg/jchuff.cpp  
+-               external/libjpeg/jcmainct.cpp  
+-               external/libjpeg/jcphuff.cpp  
+-               external/libjpeg/jcprepct.cpp  
+-               external/libjpeg/jcsample.cpp
+-               external/libjpeg/jfdctint.cpp
+-               external/libjpeg/jfdctflt.cpp
+-               external/libjpeg/jfdctfst.cpp
+-               )
 -         endif()
 +        # If we can't find libjpeg then statically compile it in.
 +        add_definitions(-DDLIB_JPEG_STATIC)
 +        set(source_files ${source_files}
-+              external/libjpeg/jcomapi.cpp
-+              external/libjpeg/jdapimin.cpp
-+              external/libjpeg/jdapistd.cpp
-+              external/libjpeg/jdatasrc.cpp
-+              external/libjpeg/jdcoefct.cpp
-+              external/libjpeg/jdcolor.cpp
-+              external/libjpeg/jddctmgr.cpp
-+              external/libjpeg/jdhuff.cpp
-+              external/libjpeg/jdinput.cpp
-+              external/libjpeg/jdmainct.cpp
-+              external/libjpeg/jdmarker.cpp
-+              external/libjpeg/jdmaster.cpp
-+              external/libjpeg/jdmerge.cpp
-+              external/libjpeg/jdphuff.cpp
-+              external/libjpeg/jdpostct.cpp
-+              external/libjpeg/jdsample.cpp
-+              external/libjpeg/jerror.cpp
-+              external/libjpeg/jidctflt.cpp
-+              external/libjpeg/jidctfst.cpp
-+              external/libjpeg/jidctint.cpp
-+              external/libjpeg/jidctred.cpp
-+              external/libjpeg/jmemmgr.cpp
-+              external/libjpeg/jmemnobs.cpp
-+              external/libjpeg/jquant1.cpp
-+              external/libjpeg/jquant2.cpp
-+              external/libjpeg/jutils.cpp  
-+              external/libjpeg/jcapimin.cpp
-+              external/libjpeg/jdatadst.cpp
-+              external/libjpeg/jcparam.cpp
-+              external/libjpeg/jcapistd.cpp
-+              external/libjpeg/jcmarker.cpp
-+              external/libjpeg/jcinit.cpp
-+              external/libjpeg/jcmaster.cpp
-+              external/libjpeg/jcdctmgr.cpp
-+              external/libjpeg/jccoefct.cpp  
-+              external/libjpeg/jccolor.cpp  
-+              external/libjpeg/jchuff.cpp  
-+              external/libjpeg/jcmainct.cpp  
-+              external/libjpeg/jcphuff.cpp  
-+              external/libjpeg/jcprepct.cpp  
-+              external/libjpeg/jcsample.cpp
-+              external/libjpeg/jfdctint.cpp
-+              external/libjpeg/jfdctflt.cpp
-+              external/libjpeg/jfdctfst.cpp
-+              )
++           external/libjpeg/jcomapi.cpp
++           external/libjpeg/jdapimin.cpp
++           external/libjpeg/jdapistd.cpp
++           external/libjpeg/jdatasrc.cpp
++           external/libjpeg/jdcoefct.cpp
++           external/libjpeg/jdcolor.cpp
++           external/libjpeg/jddctmgr.cpp
++           external/libjpeg/jdhuff.cpp
++           external/libjpeg/jdinput.cpp
++           external/libjpeg/jdmainct.cpp
++           external/libjpeg/jdmarker.cpp
++           external/libjpeg/jdmaster.cpp
++           external/libjpeg/jdmerge.cpp
++           external/libjpeg/jdphuff.cpp
++           external/libjpeg/jdpostct.cpp
++           external/libjpeg/jdsample.cpp
++           external/libjpeg/jerror.cpp
++           external/libjpeg/jidctflt.cpp
++           external/libjpeg/jidctfst.cpp
++           external/libjpeg/jidctint.cpp
++           external/libjpeg/jidctred.cpp
++           external/libjpeg/jmemmgr.cpp
++           external/libjpeg/jmemnobs.cpp
++           external/libjpeg/jquant1.cpp
++           external/libjpeg/jquant2.cpp
++           external/libjpeg/jutils.cpp
++           external/libjpeg/jcapimin.cpp
++           external/libjpeg/jdatadst.cpp
++           external/libjpeg/jcparam.cpp
++           external/libjpeg/jcapistd.cpp
++           external/libjpeg/jcmarker.cpp
++           external/libjpeg/jcinit.cpp
++           external/libjpeg/jcmaster.cpp
++           external/libjpeg/jcdctmgr.cpp
++           external/libjpeg/jccoefct.cpp
++           external/libjpeg/jccolor.cpp
++           external/libjpeg/jchuff.cpp
++           external/libjpeg/jcmainct.cpp
++           external/libjpeg/jcphuff.cpp
++           external/libjpeg/jcprepct.cpp
++           external/libjpeg/jcsample.cpp
++           external/libjpeg/jfdctint.cpp
++           external/libjpeg/jfdctflt.cpp
++           external/libjpeg/jfdctfst.cpp
++           )
           set(source_files ${source_files}
              image_loader/jpeg_loader.cpp
              image_saver/save_jpeg.cpp


### PR DESCRIPTION
- Update dlib to v19.10
- Fix numpy deps as recommended [here](http://conda-forge.readthedocs.io/en/latest/meta.html#building-against-numpy)
- Fix out-of-date patch files