### PR TITLE
Bump build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,13 +11,11 @@ source:
 
   patches:
     - lapack_sgetrf.patch      # [unix]
-    #- win_jpeg_png.patch       # [win]
-    #- win_release_flags.patch  # [win]
     - cxx11_detection.patch
 
 build:
   skip: true  # [win and py<35]
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('dlib', max_pin='x.x') }}
 
@@ -38,9 +36,6 @@ requirements:
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - jpeg
-    - libpng
-    - sqlite  # [not win]
 
 test:
   files:


### PR DESCRIPTION
Currently only 19.18 gets pulled, maybe a bump/rerender will fix it
Also no need to specify jpeg,sqlite,png in run requirements, host is enough, as these packages define exports
@conda-forge-admin please rerender